### PR TITLE
Entferne Stunden in Timecode Overlay

### DIFF
--- a/src/components/VideoThumbnail.svelte
+++ b/src/components/VideoThumbnail.svelte
@@ -36,7 +36,12 @@
         let h = hours < 10 ? '0' + hours : hours;
         let m = minutes < 10 ? '0' + minutes : minutes;
         let s = seconds < 10 ? '0' + seconds : seconds;
-        return h + ':' + m + ':' + s;
+        let mmss = m + ':' + s;
+        if (hours == 0) {
+            return mmss;
+        } else {
+            return h + ':' + mmss;
+        }
     }
 </script>
 


### PR DESCRIPTION
Bei der Clip Übersicht ist mir aufgefallen das jedes Thumbnail einen Timecode HH:MM:SS hat. Ich habe in den Commit die Stunden entfernt, sollten sie gleich 0 sein.

Das ganze ist nur eine optische Veränderung. Gerne auch ablehnen wenn der Timecode konsistent sein soll.
Neu:
![grafik](https://user-images.githubusercontent.com/18444809/163734115-968d0848-7cf6-44f4-9f4e-1893b629fd74.png)

Alt:
![grafik](https://user-images.githubusercontent.com/18444809/163734121-7d3a9de9-aff7-4ac7-b213-409df7f8192e.png)

Es wäre noch zu überlegen ob man die ``toHHMMSS`` Funktion um nennen sollte.