### PR TITLE
Add datalabels to chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "@popperjs/core": "^2.11.5",
                 "bootstrap": "^5.2.0",
                 "chart.js": "^3.8.0",
+                "chartjs-plugin-datalabels": "^2.1.0",
                 "date-fns": "^2.29.1",
                 "sass": "^1.54.0",
                 "videojs-seek-buttons": "^2.2.1",
@@ -872,6 +873,14 @@
             "version": "3.8.0",
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.0.tgz",
             "integrity": "sha512-cr8xhrXjLIXVLOBZPkBZVF6NDeiVIrPLHcMhnON7UufudL+CNeRrD+wpYanswlm8NpudMdrt3CHoLMQMxJhHRg=="
+        },
+        "node_modules/chartjs-plugin-datalabels": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.1.0.tgz",
+            "integrity": "sha512-WA6R4saSlY6mnyX78SkbSo2gGc+cj87lFi5zBrsjjYxE76JgXyxHa1OTodVCzRPoqeYJqSEOffeJ/897kRHR6w==",
+            "peerDependencies": {
+                "chart.js": "^3.0.0"
+            }
         },
         "node_modules/chokidar": {
             "version": "3.5.3",
@@ -4485,6 +4494,12 @@
             "version": "3.8.0",
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.8.0.tgz",
             "integrity": "sha512-cr8xhrXjLIXVLOBZPkBZVF6NDeiVIrPLHcMhnON7UufudL+CNeRrD+wpYanswlm8NpudMdrt3CHoLMQMxJhHRg=="
+        },
+        "chartjs-plugin-datalabels": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/chartjs-plugin-datalabels/-/chartjs-plugin-datalabels-2.1.0.tgz",
+            "integrity": "sha512-WA6R4saSlY6mnyX78SkbSo2gGc+cj87lFi5zBrsjjYxE76JgXyxHa1OTodVCzRPoqeYJqSEOffeJ/897kRHR6w==",
+            "requires": {}
         },
         "chokidar": {
             "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "@popperjs/core": "^2.11.5",
         "bootstrap": "^5.2.0",
         "chart.js": "^3.8.0",
+        "chartjs-plugin-datalabels": "^2.1.0",
         "date-fns": "^2.29.1",
         "sass": "^1.54.0",
         "videojs-seek-buttons": "^2.2.1",

--- a/src/components/ChartBar.svelte
+++ b/src/components/ChartBar.svelte
@@ -1,6 +1,7 @@
 <script>
     import { onMount } from 'svelte';
     import { Chart, registerables } from 'chart.js/dist/chart.esm';
+    import ChartDataLabels from 'chartjs-plugin-datalabels';
     import { theme } from '@stores/main';
     import { themeColors } from './StatsColors.svelte';
 
@@ -24,6 +25,9 @@
                 plugins: {
                     legend: {
                         display: false
+                    },
+                    datalabels: {
+                        color: colors?.ticks
                     }
                 },
                 scales: {
@@ -52,6 +56,7 @@
     onMount(async () => {
         let ctx = chartCanvas.getContext('2d');
         chart = new Chart(ctx, {
+            plugins: [ChartDataLabels],
             type: 'bar',
             data: {
                 labels: chartLabels,
@@ -66,6 +71,9 @@
                 plugins: {
                     legend: {
                         display: false
+                    },
+                    datalabels: {
+                        color: colors?.ticks
                     }
                 },
                 scales: {

--- a/src/components/ChartDoughnut.svelte
+++ b/src/components/ChartDoughnut.svelte
@@ -1,6 +1,7 @@
 <script>
     import { onMount } from 'svelte';
     import { Chart, registerables } from 'chart.js/dist/chart.esm';
+    import ChartDataLabels from 'chartjs-plugin-datalabels';
     import { theme } from '@stores/main';
     import { themeColors } from './StatsColors.svelte';
 
@@ -21,6 +22,9 @@
                 dataset.backgroundColor = colors?.backgroundColors;
             });
             chart.options.plugins.legend.labels.color = colors?.ticks;
+            chart.options.plugins.datalabels = {
+                color: colors?.ticks
+            };
             chart.update();
         }
     });
@@ -28,6 +32,7 @@
     onMount(async () => {
         let ctx = chartCanvas.getContext('2d');
         chart = new Chart(ctx, {
+            plugins: [ChartDataLabels],
             type: 'doughnut',
             data: {
                 labels: chartLabels,
@@ -45,6 +50,9 @@
                         labels: {
                             color: colors?.ticks
                         }
+                    },
+                    datalabels: {
+                        color: colors?.ticks
                     }
                 }
             }

--- a/src/components/ChartLine.svelte
+++ b/src/components/ChartLine.svelte
@@ -1,6 +1,7 @@
 <script>
     import { onMount } from 'svelte';
     import { Chart, registerables } from 'chart.js/dist/chart.esm';
+    import ChartDataLabels from 'chartjs-plugin-datalabels';
     import { theme } from '@stores/main';
     import { themeColors } from './StatsColors.svelte';
 
@@ -38,6 +39,9 @@
                     }
                 }
             };
+            chart.options.plugins.datalabels = {
+                color: colors?.ticks
+            };
             chart.update();
         }
     });
@@ -45,6 +49,7 @@
     onMount(async () => {
         let ctx = chartCanvas.getContext('2d');
         chart = new Chart(ctx, {
+            plugins: [ChartDataLabels],
             type: 'line',
             data: {
                 labels: chartLabels,
@@ -61,6 +66,10 @@
                 plugins: {
                     legend: {
                         display: false
+                    },
+                    datalabels: {
+                        color: colors?.ticks,
+                        align: 'end'
                     }
                 },
                 interaction: {

--- a/src/components/StatsColors.svelte
+++ b/src/components/StatsColors.svelte
@@ -64,7 +64,7 @@
         },
         solarized: {
             grid: '#073642',
-            ticks: '#839496',
+            ticks: '#eee8d5',
             backgroundColors: [
                 '#b58900',
                 '#cb4b16',

--- a/src/components/StatsColors.svelte
+++ b/src/components/StatsColors.svelte
@@ -78,8 +78,8 @@
             ]
         },
         ayaya: {
-            grid: '#073642',
-            ticks: '#ff00c8',
+            grid: '#a46c98',
+            ticks: '#073642',
             backgroundColors: [
                 '#ff00c8',
                 '#825f99',

--- a/src/themes.scss
+++ b/src/themes.scss
@@ -71,10 +71,10 @@
 
 // https://ethanschoonover.com/solarized/
 [data-theme='solarized'] {
-    --color-main: #839496;
+    --color-main: #eee8d5;
     --color-background: #002b36;
     --color-hover: #073642;
-    --color-text-muted: #eee8d5;
+    --color-text-muted: #93a1a1;
     --color-footer-background: #073642;
     --border: 1px solid var(--color-main) !important;
 }


### PR DESCRIPTION
In this PR I have added the Chartjs Datalabels plugin. With the help of this plugin I now show the numbers of the statistics without hovering the mouse over them.

Through my change, the statistics now look like this:
Light:
![grafik](https://user-images.githubusercontent.com/18444809/183251436-b349ed70-1e86-485f-978e-bd5f8ba3e475.png)

Dark:
![grafik](https://user-images.githubusercontent.com/18444809/183251441-98644773-b358-4100-b1eb-960658c220a8.png)
